### PR TITLE
Changing exceptions to be ValueError or a subclass thereof in cases wher...

### DIFF
--- a/src/isodate/isoerror.py
+++ b/src/isodate/isoerror.py
@@ -28,5 +28,5 @@
 This module defines all exception classes in the whole package.
 '''
 
-class ISO8601Error(Exception):
+class ISO8601Error(ValueError):
     '''Raised when the given ISO string can not be parsed.'''

--- a/src/isodate/isotzinfo.py
+++ b/src/isodate/isotzinfo.py
@@ -106,4 +106,4 @@ def tz_isoformat(dt, format='%Z'):
         return '%s%02d%02d' % (sign, hours, minutes)
     elif format == '%h':
         return '%s%02d' % (sign, hours)
-    raise AttributeError('unknown format string "%s"' % format)
+    raise ValueError('unknown format string "%s"' % format)


### PR DESCRIPTION
...e the error is invalid input.

Please see this page for a definition of ValueError, which should make clear why it is more appropriate: http://docs.python.org/2/library/exceptions.html#exceptions.ValueError
