### PR TITLE
Fractional duration

### DIFF
--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -101,9 +101,15 @@ def parse_duration(datestring):
     for key, val in groups.items():
         if key not in ('separator', 'sign'):
             if val is None:
-                groups[key] = "0n"
-            #print groups[key]
-            groups[key] = float(groups[key][:-1].replace(',', '.'))
+                val = '0'
+            else:
+                val = groups[key][:-1]
+            val = val.replace(',', '.')
+            if '.' in val:
+                val = float(val)
+            else:
+                val = int(val)
+            groups[key] = val
     if groups["years"] == 0 and groups["months"] == 0:
         ret = timedelta(days=groups["days"], hours=groups["hours"],
                         minutes=groups["minutes"], seconds=groups["seconds"],

--- a/src/isodate/tests/test_duration.py
+++ b/src/isodate/tests/test_duration.py
@@ -322,6 +322,13 @@ class DurationTest(unittest.TestCase):
         #        treats a != b the same b != a
         #self.assertNotEqual(timedelta(days=1), Duration(days=1))
 
+    def test_types(self):
+        '''
+        Test that integral ISO durations are parsed into integer Durations
+        '''
+        dur = parse_duration('P1Y')
+        self.assertTrue(isinstance(dur.years, int))
+
 
 def create_parsetestcase(durationstring, expectation, format, altstr):
     """


### PR DESCRIPTION
I ran into a test failure when porting a private codebase to Python 2.7.

We were doing:

``` python
import isodate, datetime
NOW = datetime.datetime.now()
P1Y = isodate.parse_duration("P1Y")
print P1Y + NOW
```

Under Python 2.6, this raises a `DeprecationWarning`:

```
site-packages/isodate/duration.py:173: DeprecationWarning: integer argument expected, got float
  newdt = other.replace(year=newyear, month=newmonth, day=newday)
```

Under Python 2.7, it throws a `TypeError`:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "site-packages/isodate/duration.py", line 173, in __radd__
    newdt = other.replace(year=newyear, month=newmonth, day=newday)
TypeError: integer argument expected, got float
```

Here are some patches, that add test coverage in this area, and avoid using floats in `Duration`s when possible.

However, a fractional `Duration` will still not be able to be used in arithmetic with a `datetime`/`date`. This could be fixed by transforming it into an integral `Duration`, at parse time. But that would come with a loss of information.

What does `P0.5M` actually mean? Is it equivalent to `P15D`? What about `P0.0001M`? Reading ISO8601 didn't give me much insight...

So, I'm ignoring fractional `Duration`s for now, unless you can suggest a good way forward.

Oh, it also occurs to me that using `Decimal` objects may be preferable to `float`s here.
