### PR TITLE
months and years are stored as decimals. enforce that in the constructor

### DIFF
--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -31,6 +31,7 @@ The class Duration allows to define durations in years and months and can be
 used as limited replacement for timedelta objects.
 '''
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 
 
 def fquotmod(val, low, high):
@@ -83,6 +84,10 @@ class Duration(object):
         '''
         Initialise this Duration instance with the given parameters.
         '''
+        if isinstance(months, float):
+            months = Decimal(str(months))
+        if isinstance(years, float):
+            years = Decimal(str(years))
         self.months = months
         self.years = years
         self.tdelta = timedelta(days, seconds, microseconds, milliseconds,


### PR DESCRIPTION
27eb4b1b7a0b21cb5bf36094bd56c34ee2a73112 introduces a test failure under Python2.6:

```
======================================================================
FAIL: test_parse (isodate.tests.test_duration.TestParseDuration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/stefanor/git/isodate/src/isodate/tests/test_duration.py", line 360, in test_parse
    self.assertEqual(result, expectation)
AssertionError: isodate.duration.Duration(0, 0, 0, years=0, months=0) != isodate.duration.Duration(0, 0, 0, years=0, months=0)

----------------------------------------------------------------------
```

This is from the test case:

```
                    'P0.5Y': (Duration(years=0.5), D_DEFAULT, None),
```

We should transform that 0.5 to a Decimal.
