### PR TITLE
Fix flake errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name='isodate',
       author_email='gerhard.weis@proclos.com',
       description='An ISO 8601 date/time/duration parser and formater',
       license='BSD',
-      #keywords = '',
+      # keywords = '',
       url='http://cheeseshop.python.org/pypi/isodate',
 
       long_description=(read('README.rst') +
@@ -77,7 +77,7 @@ setup(name='isodate',
                    'Programming Language :: Python :: 3.3',
                    'Programming Language :: Python :: Implementation :: PyPy',
                    'Topic :: Internet',
-                   'Topic :: Software Development :: Libraries :: Python Modules',
+                   ('Topic :: Software Development :'
+                    ': Libraries :: Python Modules'),
                    ],
-      **setupargs
-     )
+      **setupargs)

--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -46,7 +46,7 @@ def fquotmod(val, low, high):
     div = (a / b).to_integral(ROUND_FLOOR)
     mod = a - div * b
     # if we were not usig Decimal, it would look like this.
-    #div, mod = divmod(val - low, high - low)
+    # div, mod = divmod(val - low, high - low)
     mod += low
     return int(div), mod
 
@@ -218,7 +218,7 @@ class Duration(object):
         It is possible to subtract Duration objecs from date, datetime and
         timedelta objects.
         '''
-        #print '__rsub__:', self, other
+        # print '__rsub__:', self, other
         if isinstance(other, (date, datetime)):
             if (not(float(self.years).is_integer()
                     and float(self.months).is_integer())):

--- a/src/isodate/isodates.py
+++ b/src/isodate/isodates.py
@@ -168,7 +168,7 @@ def parse_date(datestring, yeardigits=4, expanded=False):
             sign = (groups['sign'] == '-' and -1) or 1
             if 'century' in groups:
                 return date(sign * (int(groups['century']) * 100 + 1), 1, 1)
-            if not 'month' in groups:  # weekdate or ordinal date
+            if 'month' not in groups:  # weekdate or ordinal date
                 ret = date(sign * int(groups['year']), 1, 1)
                 if 'week' in groups:
                     isotuple = ret.isocalendar()

--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -104,7 +104,7 @@ def parse_duration(datestring):
         if key not in ('separator', 'sign'):
             if val is None:
                 groups[key] = "0n"
-            #print groups[key]
+            # print groups[key]
             if key in ('years', 'months'):
                 groups[key] = Decimal(groups[key][:-1].replace(',', '.'))
             else:

--- a/src/isodate/tests/test_duration.py
+++ b/src/isodate/tests/test_duration.py
@@ -76,7 +76,7 @@ PARSE_TEST_CASES = {'P18Y9M4DT11H9M8S': (Duration(4, 8, 0, 0, 9, 11, 0, 9, 18),
                     # alternative format
                     'P0018-09-04T11:09:08': (Duration(4, 8, 0, 0, 9, 11, 0, 9,
                                                       18), D_ALT_EXT, None),
-                    #'PT000022.22': timedelta(seconds=22.22),
+                    # 'PT000022.22': timedelta(seconds=22.22),
                     }
 
 #                       d1                    d2           '+', '-', '>'
@@ -291,7 +291,7 @@ class DurationTest(unittest.TestCase):
         self.assertNotEqual(-timedelta(days=365), Duration(years=-1))
         # FIXME: this test fails in python 3... it seems like python3
         #        treats a == b the same b == a
-        #self.assertNotEqual(-timedelta(days=10), -Duration(days=10))
+        # self.assertNotEqual(-timedelta(days=10), -Duration(days=10))
 
     def test_format(self):
         '''
@@ -334,7 +334,7 @@ class DurationTest(unittest.TestCase):
         self.assertEqual(Duration(days=1), timedelta(days=1))
         # FIXME: this test fails in python 3... it seems like python3
         #        treats a != b the same b != a
-        #self.assertNotEqual(timedelta(days=1), Duration(days=1))
+        # self.assertNotEqual(timedelta(days=1), Duration(days=1))
 
     def test_totimedelta(self):
         '''


### PR DESCRIPTION
Hi. This pull request fixes the flake errors reported in the Travis Tox test (leading space in comments, line length, 'x not in y') so that the build passes.

I don't know how build 10 passed on Travis (different version of something perhaps), but you can see the errors in build 12 for pull request #10.
