### PR TITLE
Make parse_datetime raise ISO8601Error if no 'T'

### DIFF
--- a/src/isodate/isodatetime.py
+++ b/src/isodate/isodatetime.py
@@ -35,6 +35,7 @@ from datetime import datetime
 from isodate.isostrf import strftime
 from isodate.isostrf import DATE_EXT_COMPLETE, TIME_EXT_COMPLETE, TZ_EXT
 from isodate.isodates import parse_date
+from isodate.isoerror import ISO8601Error
 from isodate.isotime import parse_time
 
 
@@ -46,7 +47,11 @@ def parse_datetime(datetimestring):
     more combinations of date and time representations, than the actual
     ISO 8601:2004 standard allows.
     '''
-    datestring, timestring = datetimestring.split('T')
+    try:
+        datestring, timestring = datetimestring.split('T')
+    except ValueError:
+        raise ISO8601Error("ISO 8601 time designator 'T' missing. Unable to"
+                           " parse datetime string %r" % datetimestring)
     tmpdate = parse_date(datestring)
     tmptime = parse_time(timestring)
     return datetime.combine(tmpdate, tmptime)

--- a/src/isodate/tests/test_datetime.py
+++ b/src/isodate/tests/test_datetime.py
@@ -31,6 +31,7 @@ import unittest
 from datetime import datetime
 
 from isodate import parse_datetime, UTC, FixedOffset, datetime_isoformat
+from isodate import ISO8601Error
 from isodate import DATE_BAS_COMPLETE, TIME_BAS_MINUTE, TIME_BAS_COMPLETE
 from isodate import DATE_EXT_COMPLETE, TIME_EXT_MINUTE, TIME_EXT_COMPLETE
 from isodate import TZ_BAS, TZ_EXT, TZ_HOUR
@@ -81,7 +82,10 @@ TEST_CASES = [('19850412T1015', datetime(1985, 4, 12, 10, 15),
               ('2012-10-30T08:55:22.1234561Z',
                datetime(2012, 10, 30, 8, 55, 22, 123456, tzinfo=UTC),
                DATE_EXT_COMPLETE + 'T' + TIME_EXT_COMPLETE + '.%f' + TZ_BAS,
-               '2012-10-30T08:55:22.123456Z')
+               '2012-10-30T08:55:22.123456Z'),
+              ('2014-08-18 14:55:22.123456Z', None,
+               DATE_EXT_COMPLETE + 'T' + TIME_EXT_COMPLETE + '.%f' + TZ_BAS,
+               '2014-08-18T14:55:22.123456Z'),
               ]
 
 
@@ -103,8 +107,10 @@ def create_testcase(datetimestring, expectation, format, output):
             '''
             Parse an ISO datetime string and compare it to the expected value.
             '''
-            result = parse_datetime(datetimestring)
-            self.assertEqual(result, expectation)
+            if expectation is None:
+                self.assertRaises(ISO8601Error, parse_datetime, datetimestring)
+            else:
+                self.assertEqual(parse_datetime(datetimestring), expectation)
 
         def test_format(self):
             '''


### PR DESCRIPTION
- Make parse_datetime raise ISO8601Error if time designator 'T' is missing
  as before it would raise a ValueError that was hard to interpret.
- Alter test_parse for test_datetime to check that bad inputs raise an
  ISO8601 error. The other tests did this, but test_datetime didn't.
- Add test case where the 'T' time designator is missing from input
  datetime strings.
