### PR TITLE
Move line breaks after operators

### DIFF
--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -159,8 +159,8 @@ class Duration(object):
             newduration.tdelta = self.tdelta + other.tdelta
             return newduration
         if isinstance(other, (date, datetime)):
-            if (not(float(self.years).is_integer()
-                    and float(self.months).is_integer())):
+            if (not(float(self.years).is_integer() and
+                    float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'
                                  ' for date calculations')
             newmonth = other.month + self.months
@@ -185,8 +185,8 @@ class Duration(object):
             newduration.tdelta = self.tdelta + other
             return newduration
         if isinstance(other, (date, datetime)):
-            if (not(float(self.years).is_integer()
-                    and float(self.months).is_integer())):
+            if (not(float(self.years).is_integer() and
+                    float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'
                                  ' for date calculations')
             newmonth = other.month + self.months
@@ -226,8 +226,8 @@ class Duration(object):
         '''
         # print '__rsub__:', self, other
         if isinstance(other, (date, datetime)):
-            if (not(float(self.years).is_integer()
-                    and float(self.months).is_integer())):
+            if (not(float(self.years).is_integer() and
+                    float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'
                                  ' for date calculations')
             newmonth = other.month - self.months
@@ -258,8 +258,8 @@ class Duration(object):
         if not isinstance(other, Duration):
             return NotImplemented
         if (((self.years * 12 + self.months) ==
-             (other.years * 12 + other.months)
-             and self.tdelta == other.tdelta)):
+             (other.years * 12 + other.months) and
+             self.tdelta == other.tdelta)):
             return True
         return False
 
@@ -268,15 +268,15 @@ class Duration(object):
         If the years, month part or the timedelta part is not equal, then
         the two Durations are considered not equal.
         '''
-        if ((isinstance(other, timedelta)
-             and self.years == 0
-             and self.months == 0)):
+        if ((isinstance(other, timedelta) and
+             self.years == 0 and
+             self.months == 0)):
             return self.tdelta != other
         if not isinstance(other, Duration):
             return NotImplemented
         if (((self.years * 12 + self.months) !=
-             (other.years * 12 + other.months)
-             or self.tdelta != other.tdelta)):
+             (other.years * 12 + other.months) or
+             self.tdelta != other.tdelta)):
             return True
         return False
 

--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -136,11 +136,11 @@ def duration_isoformat(tduration, format=D_DEFAULT):
     '''
     # TODO: implement better decision for negative Durations.
     #       should be done in Duration class in consistent way with timedelta.
-    if (((isinstance(tduration, Duration)
-          and (tduration.years < 0 or tduration.months < 0
-               or tduration.tdelta < timedelta(0)))
-         or (isinstance(tduration, timedelta)
-             and (tduration < timedelta(0))))):
+    if (((isinstance(tduration, Duration) and
+          (tduration.years < 0 or tduration.months < 0 or
+           tduration.tdelta < timedelta(0))) or
+        (isinstance(tduration, timedelta) and
+         (tduration < timedelta(0))))):
         ret = '-'
     else:
         ret = ''

--- a/src/isodate/isotime.py
+++ b/src/isodate/isotime.py
@@ -71,25 +71,25 @@ def build_time_regexps():
         #    hh:mm:ss.ss ... extended format
         TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2}):"
                                            r"(?P<minute>[0-9]{2}):"
-                                           r"(?P<second>[0-9]{2}([,.][0-9]+)?)"
-                                           + TZ_REGEX))
+                                           r"(?P<second>[0-9]{2}"
+                                           r"([,.][0-9]+)?)" + TZ_REGEX))
         #    hhmmss.ss ... basic format
         TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2})"
                                            r"(?P<minute>[0-9]{2})"
-                                           r"(?P<second>[0-9]{2}([,.][0-9]+)?)"
-                                           + TZ_REGEX))
+                                           r"(?P<second>[0-9]{2}"
+                                           r"([,.][0-9]+)?)" + TZ_REGEX))
         # 2. reduced accuracy:
         #    hh:mm.mm ... extended format
         TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2}):"
-                                           r"(?P<minute>[0-9]{2}([,.][0-9]+)?)"
-                                           + TZ_REGEX))
+                                           r"(?P<minute>[0-9]{2}"
+                                           r"([,.][0-9]+)?)" + TZ_REGEX))
         #    hhmm.mm ... basic format
         TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2})"
-                                           r"(?P<minute>[0-9]{2}([,.][0-9]+)?)"
-                                           + TZ_REGEX))
+                                           r"(?P<minute>[0-9]{2}"
+                                           r"([,.][0-9]+)?)" + TZ_REGEX))
         #    hh.hh ... basic format
-        TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2}([,.][0-9]+)?)"
-                                           + TZ_REGEX))
+        TIME_REGEX_CACHE.append(re.compile(r"T?(?P<hour>[0-9]{2}"
+                                           r"([,.][0-9]+)?)" + TZ_REGEX))
     return TIME_REGEX_CACHE
 
 


### PR DESCRIPTION
Move line breaks to after operators as per PEP8 as Flake has started picking up on this in a newer version.

There were lots of flake warnings like this:
```
src/isodate/isoduration.py:140:11: W503 line break before binary operator
```