### PR TITLE
Fix ISO8601_PERIOD_REGEX to not match 'P'

### DIFF
--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -41,7 +41,8 @@ from isodate.isostrf import strftime, D_DEFAULT
 
 ISO8601_PERIOD_REGEX = re.compile(
     r"^(?P<sign>[+-])?"
-    r"P(?P<years>[0-9]+([,.][0-9]+)?Y)?"
+    r"P(?!\b)"
+    r"(?P<years>[0-9]+([,.][0-9]+)?Y)?"
     r"(?P<months>[0-9]+([,.][0-9]+)?M)?"
     r"(?P<weeks>[0-9]+([,.][0-9]+)?W)?"
     r"(?P<days>[0-9]+([,.][0-9]+)?D)?"


### PR DESCRIPTION
```
> isodate.parse_duration('P')
datatime.timedelta(0)
```
I don't think that is the intended behaviors.
