### PR TITLE
Change '__all__' in top 'init' to list of strings

### DIFF
--- a/src/isodate/__init__.py
+++ b/src/isodate/__init__.py
@@ -54,17 +54,17 @@ from isodate.isostrf import DT_BAS_WEEK_COMPLETE, DT_EXT_WEEK_COMPLETE
 from isodate.isostrf import D_DEFAULT, D_WEEK, D_ALT_EXT, D_ALT_BAS
 from isodate.isostrf import D_ALT_BAS_ORD, D_ALT_EXT_ORD
 
-__all__ = (parse_date, date_isoformat, parse_time, time_isoformat,
-           parse_datetime, datetime_isoformat, parse_duration,
-           duration_isoformat, ISO8601Error, parse_tzinfo,
-           tz_isoformat, UTC, FixedOffset, LOCAL, Duration,
-           strftime, DATE_BAS_COMPLETE, DATE_BAS_ORD_COMPLETE,
-           DATE_BAS_WEEK, DATE_BAS_WEEK_COMPLETE, DATE_CENTURY,
-           DATE_EXT_COMPLETE, DATE_EXT_ORD_COMPLETE, DATE_EXT_WEEK,
-           DATE_EXT_WEEK_COMPLETE, DATE_MONTH, DATE_YEAR,
-           TIME_BAS_COMPLETE, TIME_BAS_MINUTE, TIME_EXT_COMPLETE,
-           TIME_EXT_MINUTE, TIME_HOUR, TZ_BAS, TZ_EXT, TZ_HOUR,
-           DT_BAS_COMPLETE, DT_EXT_COMPLETE, DT_BAS_ORD_COMPLETE,
-           DT_EXT_ORD_COMPLETE, DT_BAS_WEEK_COMPLETE,
-           DT_EXT_WEEK_COMPLETE, D_DEFAULT, D_WEEK, D_ALT_EXT,
-           D_ALT_BAS, D_ALT_BAS_ORD, D_ALT_EXT_ORD)
+__all__ = ['parse_date', 'date_isoformat', 'parse_time', 'time_isoformat',
+           'parse_datetime', 'datetime_isoformat', 'parse_duration',
+           'duration_isoformat', 'ISO8601Error', 'parse_tzinfo',
+           'tz_isoformat', 'UTC', 'FixedOffset', 'LOCAL', 'Duration',
+           'strftime', 'DATE_BAS_COMPLETE', 'DATE_BAS_ORD_COMPLETE',
+           'DATE_BAS_WEEK', 'DATE_BAS_WEEK_COMPLETE', 'DATE_CENTURY',
+           'DATE_EXT_COMPLETE', 'DATE_EXT_ORD_COMPLETE', 'DATE_EXT_WEEK',
+           'DATE_EXT_WEEK_COMPLETE', 'DATE_MONTH', 'DATE_YEAR',
+           'TIME_BAS_COMPLETE', 'TIME_BAS_MINUTE', 'TIME_EXT_COMPLETE',
+           'TIME_EXT_MINUTE', 'TIME_HOUR', 'TZ_BAS', 'TZ_EXT', 'TZ_HOUR',
+           'DT_BAS_COMPLETE', 'DT_EXT_COMPLETE', 'DT_BAS_ORD_COMPLETE',
+           'DT_EXT_ORD_COMPLETE', 'DT_BAS_WEEK_COMPLETE',
+           'DT_EXT_WEEK_COMPLETE', 'D_DEFAULT', 'D_WEEK', 'D_ALT_EXT',
+           'D_ALT_BAS', 'D_ALT_BAS_ORD', 'D_ALT_EXT_ORD']


### PR DESCRIPTION
The `__all__` in top level `__init__.py` should be  a list of strings.

See: [Importing * From a Package](https://docs.python.org/2/tutorial/modules.html#importing-from-a-package)