### PR TITLE
Make Duration objects hashable

### DIFF
--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -134,6 +134,13 @@ class Duration(object):
             self.tdelta.days, self.tdelta.seconds,
             self.tdelta.microseconds, self.years, self.months)
 
+    def __hash__(self):
+        '''
+        Return a hash of this instance so that it can be used in, for
+        example, dicts and sets.
+        '''
+        return hash((self.tdelta, self.months, self.years))
+
     def __neg__(self):
         """
         A simple unary minus.

--- a/src/isodate/tests/test_duration.py
+++ b/src/isodate/tests/test_duration.py
@@ -279,6 +279,23 @@ class DurationTest(unittest.TestCase):
         self.assertEqual('isodate.duration.Duration(10, 10, 0,'
                          ' years=10, months=10)', repr(dur))
 
+    def test_hash(self):
+        '''
+        Test __hash__ for Duration objects.
+        '''
+        dur1 = Duration(10, 10, years=10, months=10)
+        dur2 = Duration(9, 9, years=9, months=9)
+        dur3 = Duration(10, 10, years=10, months=10)
+        self.assertNotEqual(hash(dur1), hash(dur2))
+        self.assertNotEqual(id(dur1), id(dur2))
+        self.assertEqual(hash(dur1), hash(dur3))
+        self.assertNotEqual(id(dur1), id(dur3))
+        durSet = set()
+        durSet.add(dur1)
+        durSet.add(dur2)
+        durSet.add(dur3)
+        self.assertEqual(len(durSet), 2)
+
     def test_neg(self):
         '''
         Test __neg__ for Duration objects.

--- a/src/isodate/tests/test_duration.py
+++ b/src/isodate/tests/test_duration.py
@@ -272,7 +272,7 @@ class DurationTest(unittest.TestCase):
 
     def test_repr(self):
         '''
-        Test __repr__ and __str__ for Duration obqects.
+        Test __repr__ and __str__ for Duration objects.
         '''
         dur = Duration(10, 10, years=10, months=10)
         self.assertEqual('10 years, 10 months, 10 days, 0:00:10', str(dur))


### PR DESCRIPTION
Duration objects are not currently hashable. I need them to be hashable because I'm using them in sets/dicts. This PR implements the `__hash__()` method and also adds the appropriate unit tests.