### PR TITLE
isodate.UTC remains the same object in a pickle

### DIFF
--- a/src/isodate/tests/test_pickle.py
+++ b/src/isodate/tests/test_pickle.py
@@ -36,6 +36,12 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(len(failed), 0, "pickle protos failed: %s" %
                          str(failed))
 
+    def test_pickle_utc(self):
+        '''
+        isodate.UTC objects remain the same after pickling.
+        '''
+        self.assertTrue(isodate.UTC is pickle.loads(pickle.dumps(isodate.UTC)))
+
 
 def test_suite():
     '''

--- a/src/isodate/tzinfo.py
+++ b/src/isodate/tzinfo.py
@@ -36,8 +36,22 @@ class Utc(tzinfo):
         '''
         return ZERO
 
+    def __reduce__(self):
+        '''
+        When unpickling a Utc object, return the default instance below, UTC.
+        '''
+        return _Utc, ()
+
+
 UTC = Utc()
 # the default instance for UTC.
+
+
+def _Utc():
+    '''
+    Helper function for unpickling a Utc object.
+    '''
+    return UTC
 
 
 class FixedOffset(tzinfo):


### PR DESCRIPTION
This solves https://github.com/gweis/isodate/issues/28
