### PR TITLE
Duration: support addition and subtraction with arrow objects

### DIFF
--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -153,8 +153,8 @@ class Duration(object):
 
     def __add__(self, other):
         '''
-        Durations can be added with Duration, timedelta, date and datetime
-        objects.
+        Durations can be added with Duration, timedelta, date, datetime and
+        arrow objects.
         '''
         if isinstance(other, timedelta):
             newduration = Duration(years=self.years, months=self.months)
@@ -165,7 +165,14 @@ class Duration(object):
                                    months=self.months + other.months)
             newduration.tdelta = self.tdelta + other.tdelta
             return newduration
-        if isinstance(other, (date, datetime)):
+
+        try:
+            import arrow
+            others = (date, datetime, arrow.Arrow)
+        except ImportError:
+            others = (date, datetime)
+
+        if isinstance(other, others):
             if (not(float(self.years).is_integer() and
                     float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'
@@ -185,13 +192,20 @@ class Duration(object):
 
     def __radd__(self, other):
         '''
-        Add durations to timedelta, date and datetime objects.
+        Add durations to timedelta, date, datetime and arrow objects.
         '''
         if isinstance(other, timedelta):
             newduration = Duration(years=self.years, months=self.months)
             newduration.tdelta = self.tdelta + other
             return newduration
-        if isinstance(other, (date, datetime)):
+
+        try:
+            import arrow
+            others = (date, datetime, arrow.Arrow)
+        except ImportError:
+            others = (date, datetime)
+
+        if isinstance(other, others):
             if (not(float(self.years).is_integer() and
                     float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'
@@ -249,11 +263,17 @@ class Duration(object):
 
     def __rsub__(self, other):
         '''
-        It is possible to subtract Duration objecs from date, datetime and
-        timedelta objects.
+        It is possible to subtract Duration objecs from date, datetime, arrow
+        and timedelta objects.
         '''
         # print '__rsub__:', self, other
-        if isinstance(other, (date, datetime)):
+        try:
+            import arrow
+            others = (date, datetime, arrow.Arrow)
+        except ImportError:
+            others = (date, datetime)
+
+        if isinstance(other, others):
             if (not(float(self.years).is_integer() and
                     float(self.months).is_integer())):
                 raise ValueError('fractional years or months not supported'


### PR DESCRIPTION
This will allow `isodate` to support addition and substraction with `arrow` objects.

Currently, the `__radd__` and `__rsub__` methods are pending on crsmithdev/arrow#344, as `arrow` currently raises `TypeError` instead of returning `NotImplemented` (which results into python not looking at `isodate`'s methods for that).

`isodate` suffers from the same issue (rasing `TypeError` instead of returning `NotImplemented`). This however won't affect the behaviour with `arrow` objects, so I'll address this in another PR.
