### PR TITLE
.travis.yml: drop py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27
-  - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=pypy


### PR DESCRIPTION
Support for Python 3.0-3.2 was dropped, so tox will always fail for
these versions anyways
