### PR TITLE
README.rst: remove reference to buildout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Further information:
 The doc strings and unit tests should provide rather detailed information about
 the methods and their limitations.
 
-The source release provides a *setup.py* script and a *buildout.cfg*. Both can
-be used to run the unit tests included.
+The source release provides a *setup.py* script,
+which can be used to run the unit tests included.
 
 Source code is available at `<http://github.com/gweis/isodate>`_.


### PR DESCRIPTION
buildout.cfg was removed in 83f5edfefcd9af9259e11fed0158b588159d24b1