### PR TITLE
Milliseconds round down

### DIFF
--- a/src/isodate/isotime.py
+++ b/src/isodate/isotime.py
@@ -125,6 +125,8 @@ def parse_time(timestring):
             if 'second' in groups:
                 # round to microseconds if fractional seconds are more precise
                 second = Decimal(groups['second']).quantize(Decimal('.000001'))
+                second = min(second, Decimal('59.999999'))
+
                 microsecond = (second - int(second)) * int(1e6)
                 # int(...) ... no rounding
                 # to_integral() ... rounding


### PR DESCRIPTION
If someone send time with second's precision with more than 6 decimal places you may have an error in `time()` function.

For example: (and I've very got it!)

`2017-11-29T10:59:59.9999999Z` - this will have 60.000000 seconds after time parsing and raise the error.

