### PR TITLE
Allow control over return type of parse_duration

### DIFF
--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -54,7 +54,7 @@ ISO8601_PERIOD_REGEX = re.compile(
 # regular expression to parse ISO duration strings.
 
 
-def parse_duration(datestring, as_timedelta_if_possible: bool = True):
+def parse_duration(datestring, as_timedelta_if_possible=True):
     """
     Parses an ISO 8601 durations into datetime.timedelta or Duration objects.
 

--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -89,7 +89,11 @@ def parse_duration(datestring, as_timedelta_if_possible=True):
         # try alternative format:
         if datestring.startswith("P"):
             durdt = parse_datetime(datestring[1:])
-            if as_timedelta_if_possible and durdt.year == 0 and durdt.month == 0:
+            if (
+                as_timedelta_if_possible
+                and durdt.year == 0
+                and durdt.month == 0
+            ):
                 # FIXME: currently not possible in alternative format
                 # create timedelta
                 ret = timedelta(days=durdt.day, seconds=durdt.second,
@@ -115,7 +119,11 @@ def parse_duration(datestring, as_timedelta_if_possible=True):
                 # these values are passed into a timedelta object,
                 # which works with floats.
                 groups[key] = float(groups[key][:-1].replace(',', '.'))
-    if as_timedelta_if_possible and groups["years"] == 0 and groups["months"] == 0:
+    if (
+        as_timedelta_if_possible
+        and groups["years"] == 0
+        and groups["months"] == 0
+    ):
         ret = timedelta(days=groups["days"], hours=groups["hours"],
                         minutes=groups["minutes"], seconds=groups["seconds"],
                         weeks=groups["weeks"])


### PR DESCRIPTION
My main suggested edit here is to allow control over the return type of `parse_duration` (implemented as a non-breaking revision). I explain below why I feel this is important. I also fixed a typo and changed an if-else block to its logical equivalent, so it is clear that it follows the same reasoning as another if-else block (line 218 onwards).

### Why do I feel control over the return type of `parse_duration` is important?

The underlying issue at play here is the interpretation of the nominal duration "P1D" as an absolute duration `datetime.timedelta(days=1)`. That is, a `datetime.timedelta(days=1)` is defined as exactly 24 hours, whereas ISO 8601 defines "P1D" as a calendar day, whose exact duration depends on its positioning in a calendar. For example, for the Europe/Amsterdam timezone (which happens to be my timezone), daylight saving time will start on March 28th 2021, which means March 28th in my calendar has 23 hours.

If you'd like, I can make a ticket for this, too, but I'd like to restrict this PR to merely allowing control over the return type. By setting `as_timedelta_if_possible=False`, the `isodate.Duration` could be used to determine the exact duration of nominal durations by their position in a calendar. For example, using `pandas.DateOffset` (which is based on `dateutil.relativedelta.relativedelta`):

```
import datetime
import isodate
import pandas as pd
import pytz


duration_str = "P1D"
timezone_str = "Europe/Amsterdam"
nominal_duration = isodate.parse_duration(duration_str, as_timedelta_if_possible=False)

def exact_duration_given_position_in_calendar(nominal_duration: isodate.Duration, start: datetime.datetime) -> datetime.timedelta:
    """Determine the exact duration of a nominal isodate.Duration object, given its starting position in a calendar."""
    years = nominal_duration.years
    months = nominal_duration.months
    days = nominal_duration.days
    seconds = nominal_duration.tdelta.seconds
    offset = pd.DateOffset(
        years=years, months=months, days=days, seconds=seconds
    )
    return (pd.Timestamp(start) + offset).to_pydatetime() - start

dates = [
    [2021, 3, 27],  # 1 day before
    [2021, 3, 28],  # day of transition to Daylight Saving Time
    [2021, 3, 29],  # 1 day after
]
for date in dates:
    start = pytz.timezone(timezone_str).localize(
        datetime.datetime(*date)
    )
    print(f"If start positioned at {start} in timezone {timezone_str}, P1D takes {exact_duration_given_position_in_calendar(nominal_duration, start)}.")

# If start positioned at 2021-03-27 00:00:00+01:00 in timezone Europe/Amsterdam, P1D takes 1 day, 0:00:00.
# If start positioned at 2021-03-28 00:00:00+01:00 in timezone Europe/Amsterdam, P1D takes 23:00:00.
# If start positioned at 2021-03-29 00:00:00+02:00 in timezone Europe/Amsterdam, P1D takes 1 day, 0:00:00.
```