### PR TITLE
Drop support for EOL Python <= 3.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{
-            hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.10.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
 
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,22 +5,10 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
 
-  - repo: https://github.com/psf/black
-    rev: 21.12b0
-    hooks:
-      - id: black
-        args: [--target-version=py36]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
         args:
           - "--max-line-length=88"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,38 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: [--py37-plus]
+
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+        args: [--target-version=py36]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 4.0.1
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
         args:
           - "--max-line-length=88"
 
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-blanket-noqa
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ ISO 8601 date/time parser
     :target: https://coveralls.io/r/gweis/isodate?branch=master
     :alt: Coveralls
 .. image:: https://img.shields.io/pypi/v/isodate.svg
-    :target: https://pypi.python.org/pypi/isodate/          
+    :target: https://pypi.python.org/pypi/isodate/
     :alt: Latest Version
 .. image:: https://img.shields.io/pypi/l/isodate.svg
-    :target: https://pypi.python.org/pypi/isodate/          
+    :target: https://pypi.python.org/pypi/isodate/
     :alt: License
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     # keywords = '',
     url="https://github.com/gweis/isodate/",
     long_description=(read("README.rst") + read("CHANGES.txt") + read("TODO.txt")),
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         # 'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet",
-        ("Topic :: Software Development :" ": Libraries :: Python Modules"),
+        "Topic :: Software Development :" ": Libraries :: Python Modules",
     ],
     test_suite="isodate.tests.test_suite",
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet",
-        "Topic :: Software Development :" ": Libraries :: Python Modules",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     test_suite="isodate.tests.test_suite",
 )

--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -38,7 +38,7 @@ def max_days_in_month(year, month):
     return 28
 
 
-class Duration(object):
+class Duration:
     """
     A class which represents a duration.
 


### PR DESCRIPTION
Also move testing from Travis CI to GitHub Actions
 * also allows testing on macOS and Windows
 * 20 parallel jobs instead of 4
 * Travis CI has an uncertain OSS future
 * For example: https://github.com/hugovk/isodate/actions/runs/775454949
 
Move coverage from Coveralls to Codecov
 * For example: https://app.codecov.io/gh/hugovk/isodate/

Run Flake8 via pre-commit
 * Pins versions
 * Makes it easy to run on CI and as optional pre-commit hook
 * Add some other handy pre-commit fixers/linters too

---

Here's the pip installs for isodate from PyPI for March 2021, showing low numbers for EOL versions:

| category | percent | downloads  |
|----------|--------:|-----------:|
| 3.7      |  51.39% | 16,518,933 |
| 3.6      |  25.40% |  8,165,006 |
| 3.8      |  10.28% |  3,305,128 |
| 3.5      |   4.76% |  1,529,899 |
| 2.7      |   3.16% |  1,016,819 |
| null     |   3.06% |    982,390 |
| 3.9      |   1.92% |    617,791 |
| 3.4      |   0.03% |     10,536 |
| 3.10     |   0.00% |        540 |
| 3.3      |   0.00% |         15 |
| 2.6      |   0.00% |         13 |
| Total    |         | 32,147,070 |

Date range: 2021-03-01 - 2021-03-31

Source: `pip install -U pypistats && pypistats python_minor isodate --last-month`