### PR TITLE
ci: Run tests through python -m unittest instead of setup.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,11 @@ envlist =
 deps =
 setenv =
     PYTHONWARNINGS = default
+package = editable-legacy
 commands =
-    {envpython} setup.py test
-    pip install --quiet coverage
-    {envpython} setup.py clean --all
-    coverage run setup.py test
-    coverage xml
+    {envpython} -m pip install --quiet coverage
+    {envpython} -m coverage run -m unittest isodate.tests.test_suite
+    {envpython} -m coverage xml
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
Running tests through setup.py is deprecated. This avoids the warning
message.
