### PR TITLE
Update status badges in Readme to point at current CI infra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@
 ISO 8601 date/time parser
 =========================
 
-.. image:: https://travis-ci.org/gweis/isodate.svg?branch=master
-    :target: https://travis-ci.org/gweis/isodate
-    :alt: Travis-CI
-.. image:: https://coveralls.io/repos/gweis/isodate/badge.svg?branch=master
-    :target: https://coveralls.io/r/gweis/isodate?branch=master
-    :alt: Coveralls
+.. image:: https://github.com/gweis/isodate/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/gweis/isodate/actions/workflows/test.yml
+    :alt: GitHub Actions
+.. image:: https://img.shields.io/codecov/c/gh/gweis/isodate
+    :target: https://app.codecov.io/gh/gweis/isodate
+    :alt: Codecov
 .. image:: https://img.shields.io/pypi/v/isodate.svg
     :target: https://pypi.python.org/pypi/isodate/
     :alt: Latest Version


### PR DESCRIPTION
This PR updates the Travis/Coveralls badges to GitHub Actions/Codecov.

As an aside, Codecov reporting seems to be broken – the "Upload coverage" step says:

```
info - 2024-10-09 01:50:06,363 -- ci service found: github-actions
warning - 2024-10-09 01:50:06,369 -- No config file could be found. Ignoring config.
Error: Codecov token not found. Please provide Codecov token with -t flag.
```
